### PR TITLE
Add local aspire script for OTel and Copilot Studio Client

### DIFF
--- a/samples/nodejs/copilotstudio-webchat-react/.gitignore
+++ b/samples/nodejs/copilotstudio-webchat-react/.gitignore
@@ -1,0 +1,6 @@
+.aspire/
+.env
+node_modules/
+public/dist/
+src/settings.js
+*.tsbuildinfo

--- a/samples/nodejs/copilotstudio-webchat-react/README.md
+++ b/samples/nodejs/copilotstudio-webchat-react/README.md
@@ -111,6 +111,18 @@ This step requires permissions to create application identities in your Azure te
 3. **Open your browser:**
    - Navigate to [http://localhost:3000](http://localhost:3000) to interact with your Copilot Studio bot via the WebChat interface.
 
+### Optional: view browser telemetry with Aspire
+
+Run the sample and a local Aspire Dashboard together:
+
+```bash
+npm run aspire
+```
+
+Aspire prints the dashboard URL in the terminal. Open the dashboard, then use the **URLs** column to open **webchat**. The dashboard shows browser document-load and network-fetch traces. It does not show telemetry from the Copilot Studio agent, which runs outside this sample.
+
+This local development exporter sends browser traces directly to the anonymous Aspire Dashboard. Do not use this configuration in production; send browser telemetry through a server-side collector or proxy instead.
+
 ## 6. How It Works
 
 This is a pure client-side React application that connects directly to Copilot Studio:

--- a/samples/nodejs/copilotstudio-webchat-react/README.md
+++ b/samples/nodejs/copilotstudio-webchat-react/README.md
@@ -116,6 +116,7 @@ This step requires permissions to create application identities in your Azure te
 Run the sample and a local Aspire Dashboard together:
 
 ```bash
+npm run build
 npm run aspire
 ```
 

--- a/samples/nodejs/copilotstudio-webchat-react/apphost/apphost.mts
+++ b/samples/nodejs/copilotstudio-webchat-react/apphost/apphost.mts
@@ -1,0 +1,10 @@
+import { createBuilder, OtlpProtocol } from './.aspire/modules/aspire.mjs'
+
+const builder = await createBuilder()
+
+await builder
+  .addExecutable('webchat', 'npm', '..', ['run', 'start'])
+  .withHttpEndpoint({ port: 3000, targetPort: 3000, isProxied: false })
+  .withOtlpExporter({ protocol: OtlpProtocol.HttpProtobuf })
+
+await builder.build().run()

--- a/samples/nodejs/copilotstudio-webchat-react/apphost/apphost.mts
+++ b/samples/nodejs/copilotstudio-webchat-react/apphost/apphost.mts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 import { createBuilder, OtlpProtocol } from './.aspire/modules/aspire.mjs'
 
 const builder = await createBuilder()

--- a/samples/nodejs/copilotstudio-webchat-react/apphost/package.json
+++ b/samples/nodejs/copilotstudio-webchat-react/apphost/package.json
@@ -3,11 +3,11 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "tsx": "^4.23.5",
-    "typescript": "^5.8.3",
-    "vscode-jsonrpc": "^8.2.1"
+    "tsx": "4.23.5",
+    "typescript": "5.8.3",
+    "vscode-jsonrpc": "8.2.1"
   },
   "engines": {
-    "node": "^20.19.0 || ^22.13.0 || >=24"
+    "node": ">=20"
   }
 }

--- a/samples/nodejs/copilotstudio-webchat-react/apphost/package.json
+++ b/samples/nodejs/copilotstudio-webchat-react/apphost/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "copilotstudio-webchat-react-apphost",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "tsx": "^4.23.5",
+    "typescript": "^5.8.3",
+    "vscode-jsonrpc": "^8.2.1"
+  },
+  "engines": {
+    "node": "^20.19.0 || ^22.13.0 || >=24"
+  }
+}

--- a/samples/nodejs/copilotstudio-webchat-react/apphost/tsconfig.apphost.json
+++ b/samples/nodejs/copilotstudio-webchat-react/apphost/tsconfig.apphost.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "./dist/apphost",
+    "rootDir": "."
+  },
+  "include": [
+    "apphost.mts",
+    ".aspire/modules/aspire.mts",
+    ".aspire/modules/base.mts",
+    ".aspire/modules/transport.mts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/samples/nodejs/copilotstudio-webchat-react/aspire.config.json
+++ b/samples/nodejs/copilotstudio-webchat-react/aspire.config.json
@@ -1,0 +1,21 @@
+{
+  "appHost": {
+    "path": "apphost/apphost.mts",
+    "language": "typescript/nodejs"
+  },
+  "packages": {
+    "Aspire.Hosting.JavaScript": "13.4.6"
+  },
+  "profiles": {
+    "http": {
+      "applicationUrl": "http://localhost:18888",
+      "environmentVariables": {
+        "ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL": "http://localhost:4318",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:18891",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true",
+        "ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS": "true",
+        "ASPIRE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/samples/nodejs/copilotstudio-webchat-react/package-lock.json
+++ b/samples/nodejs/copilotstudio-webchat-react/package-lock.json
@@ -12,8 +12,8 @@
         "apphost"
       ],
       "dependencies": {
-        "@azure/msal-browser": "^4.13.1",
-        "@microsoft/agents-copilotstudio-client": "^1.5.1",
+        "@azure/msal-browser": "4.13.1",
+        "@microsoft/agents-copilotstudio-client": "1.5.1",
         "@opentelemetry/api": "1.9.1",
         "@opentelemetry/context-zone": "2.10.0",
         "@opentelemetry/exporter-trace-otlp-proto": "0.221.0",
@@ -33,7 +33,7 @@
         "@microsoft/aspire-cli": "13.4.6",
         "@types/react": "16.14.65",
         "@types/react-dom": "16.9.0",
-        "esbuild": "^0.25.9"
+        "esbuild": "0.25.9"
       },
       "engines": {
         "node": ">=20"
@@ -42,12 +42,26 @@
     "apphost": {
       "name": "copilotstudio-webchat-react-apphost",
       "devDependencies": {
-        "tsx": "^4.23.5",
-        "typescript": "^5.8.3",
-        "vscode-jsonrpc": "^8.2.1"
+        "tsx": "4.23.5",
+        "typescript": "5.8.3",
+        "vscode-jsonrpc": "8.2.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": ">=20"
+      }
+    },
+    "apphost/node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@angular/common": {
@@ -94,20 +108,22 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.22.0.tgz",
-      "integrity": "sha512-JLWHzAW1aZ/L190Th56jN+2t3T1dMvXOs1obXYLEr3ZWi81vVmBCt0di3mPvTTOiWoE0Cf/4hVQ/LINilqjObA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.13.1.tgz",
+      "integrity": "sha512-oTp2zhVljB2CRp87swOTsBcqLDrvZq9In+yDMBzuuMN4z2wrIU6ITHBZlLfs+FaAVmM1zY3k7ITekXaJ2bsDKA==",
+      "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "15.12.0"
+        "@azure/msal-common": "15.7.0"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "15.12.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.12.0.tgz",
-      "integrity": "sha512-4ucXbjVw8KJ5QBgnGJUeA07c8iznwlk5ioHIhI4ASXcXgcf2yRFhWzYOyWg/cI49LC9ekpFJeQtO3zjDTbl6TQ==",
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.7.0.tgz",
+      "integrity": "sha512-m9M5hoFoxhe/HlXNVa4qBHekrX60CVPkWzsjhKQGuzw/OPOmurosKRPDIMn8fug/E1hHI5v33DvT1LVJfItjcg==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -4934,8 +4950,9 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
       "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/samples/nodejs/copilotstudio-webchat-react/package-lock.json
+++ b/samples/nodejs/copilotstudio-webchat-react/package-lock.json
@@ -8,21 +8,46 @@
       "name": "copilotstudio-webchat-react",
       "version": "0.1.0",
       "license": "MIT",
+      "workspaces": [
+        "apphost"
+      ],
       "dependencies": {
         "@azure/msal-browser": "^4.13.1",
         "@microsoft/agents-copilotstudio-client": "^1.5.1",
+        "@opentelemetry/api": "1.9.1",
+        "@opentelemetry/context-zone": "2.10.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.221.0",
+        "@opentelemetry/instrumentation": "0.221.0",
+        "@opentelemetry/instrumentation-document-load": "0.66.0",
+        "@opentelemetry/instrumentation-fetch": "0.221.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace-base": "2.10.0",
+        "@opentelemetry/sdk-trace-web": "2.10.0",
+        "@opentelemetry/semantic-conventions": "1.39.0",
         "botframework-webchat": "4.18.1-main.20251219.4ef3594",
         "botframework-webchat-fluent-theme": "4.18.1-main.20251219.4ef3594",
         "react": "16.8.6",
         "react-dom": "16.8.6"
       },
       "devDependencies": {
+        "@microsoft/aspire-cli": "13.4.6",
         "@types/react": "16.14.65",
         "@types/react-dom": "16.9.0",
         "esbuild": "^0.25.9"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "apphost": {
+      "name": "copilotstudio-webchat-react-apphost",
+      "devDependencies": {
+        "tsx": "^4.23.5",
+        "typescript": "^5.8.3",
+        "vscode-jsonrpc": "^8.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@angular/common": {
@@ -845,6 +870,404 @@
         }
       }
     },
+    "node_modules/@microsoft/aspire-cli": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/aspire-cli/-/aspire-cli-13.4.6.tgz",
+      "integrity": "sha512-YC1JXrFj68vQzNxqUmcAr1yN3QRPCoh/TyTWl4zs/Ow5lp1oiOIaqbhXck5DERhEWzx1Ktk2Zk3fCLYjjypCgA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "aspire": "bin/aspire.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@microsoft/aspire-cli-linux-arm64": "13.4.6",
+        "@microsoft/aspire-cli-linux-musl-x64": "13.4.6",
+        "@microsoft/aspire-cli-linux-x64": "13.4.6",
+        "@microsoft/aspire-cli-osx-arm64": "13.4.6",
+        "@microsoft/aspire-cli-osx-x64": "13.4.6",
+        "@microsoft/aspire-cli-win-arm64": "13.4.6",
+        "@microsoft/aspire-cli-win-x64": "13.4.6"
+      }
+    },
+    "node_modules/@microsoft/aspire-cli-linux-arm64": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/aspire-cli-linux-arm64/-/aspire-cli-linux-arm64-13.4.6.tgz",
+      "integrity": "sha512-utk7/R695dJvAFnJemXi2826lacMbTTq5IEsbTD6CDEr4AKEwo2P8yJ5q86/X2Tr8MtPdAgPgv5hiXNtMDXm4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@microsoft/aspire-cli-linux-musl-x64": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/aspire-cli-linux-musl-x64/-/aspire-cli-linux-musl-x64-13.4.6.tgz",
+      "integrity": "sha512-pTAOh779+E27s8iFiAIGWnmPRX8avUM620/2PNItp9PCvJ86sCLw/KPQ+NJj1G6scEMGjYNFUt/6XlS4/LqErA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@microsoft/aspire-cli-linux-x64": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/aspire-cli-linux-x64/-/aspire-cli-linux-x64-13.4.6.tgz",
+      "integrity": "sha512-Z3EIfsYU4ofSdrvbk/Ee8GoYKlFykI2Fz+gzSqn82U4o8tdYs6BMDMdmNMk9AR+H7SkhMlZhQXottc9oEJ9K2w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@microsoft/aspire-cli-osx-arm64": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/aspire-cli-osx-arm64/-/aspire-cli-osx-arm64-13.4.6.tgz",
+      "integrity": "sha512-0Dfq+9hIndbiKytAwhsNnFLgZkZ4xlMJNo80ff4tsIltd/SV9YTssxAmHXZI5v8yUH71qAZa4ttFXsH7Oc8PRA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@microsoft/aspire-cli-osx-x64": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/aspire-cli-osx-x64/-/aspire-cli-osx-x64-13.4.6.tgz",
+      "integrity": "sha512-k2WV4NSbOzNV/Kiq+4YOWZJ0yxZEgpdHzKzb7dz5rv1rMC490PzY+O5KZ9WEZd8z0XXnK/5dR62jXpkxCxjNCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@microsoft/aspire-cli-win-arm64": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/aspire-cli-win-arm64/-/aspire-cli-win-arm64-13.4.6.tgz",
+      "integrity": "sha512-UkBejnPOty6KKKG5L1jJIUYnAPoxzV1JluqJoQkOts46EBqQJbfvyzS9KTvBhNVAVj/z97T1ywwTGMm5L4sSjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@microsoft/aspire-cli-win-x64": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/aspire-cli-win-x64/-/aspire-cli-win-x64-13.4.6.tgz",
+      "integrity": "sha512-IFNdi89nuYoWUzDRn56Lvo08C09Brm9ySGWcagxNyLbVmsngaATZSlpwhGaNz103kClEkoAa0QTc1pROULhT1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.221.0.tgz",
+      "integrity": "sha512-OlanaW1vv7ufTqQ3/fPLI4arGt5ZoM+P8abOMki6uEYnpRazepSWDwDnnw+la7kE26SHVC18//SMccrDvLKOXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-zone": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone/-/context-zone-2.10.0.tgz",
+      "integrity": "sha512-Ats9++P6RdfCqWb5jGGwTFVgZJTkIONFFNyRjJTAJZnSwkg3/APWNc7gCGPfUZuCdQA0+nhGTrRk3bSHcoSUuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-zone-peer-dep": "2.10.0",
+        "zone.js": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0 || ^0.15.0 || ^0.16.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-zone-peer-dep": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-zone-peer-dep/-/context-zone-peer-dep-2.10.0.tgz",
+      "integrity": "sha512-dyt6PJxfocKhQJjoMEIdPbcKnwJKV9waF6vXL9g5sSTUsp4GZXsx/faRR95vl41NANzvUYXVnhulhp57xW+G+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0",
+        "zone.js": "^0.10.2 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^0.14.0 || ^0.15.0 || ^0.16.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.221.0.tgz",
+      "integrity": "sha512-Z9i2T7vgZbWe9rSLYxXVIbeW+XyzUq4rZanW3ZyVNwVDqCsh0EJKUgBWWQ0CZfeuUA+RQPzKgJQHMuWAUnKqXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/otlp-exporter-base": "0.221.0",
+        "@opentelemetry/otlp-transformer": "0.221.0",
+        "@opentelemetry/sdk-trace": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.221.0.tgz",
+      "integrity": "sha512-cCk80Z/iRDf/5gfsKMB4f74LqVA5yKETB/9ojPzVW/6/f70iu89nJvGxsFCxx4XfSohaOofkU19kiYm84AiAlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.221.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-document-load": {
+      "version": "0.66.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-document-load/-/instrumentation-document-load-0.66.0.tgz",
+      "integrity": "sha512-e4ymSy64SFKd1TYnbFOpdInuw0x8mRzONdHnfsaTyFojiizDjwNv9klYUrIxmVQ/J2RLFvnKYHwgrgc/u2yFZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.9.0",
+        "@opentelemetry/instrumentation": "^0.221.0",
+        "@opentelemetry/sdk-trace-web": "^2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.23.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-fetch": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fetch/-/instrumentation-fetch-0.221.0.tgz",
+      "integrity": "sha512-PPfEC0dIvhieidxtajOsbgFZ2RBUhCsk1ztHE6I5uinNc4JocL+UNRQY6iCBsckI0rjTwYvsYRYOJUjGyLhIug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/instrumentation": "0.221.0",
+        "@opentelemetry/sdk-trace-web": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.221.0.tgz",
+      "integrity": "sha512-UFPIq80OH3Ns/oPFHRj14d4DTOxUo+MUFU8hUiCq5jTqFhdeJnfVSANHT+xp92409cA+oxzvlZCe6NM1wvCuBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/otlp-transformer": "0.221.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.221.0.tgz",
+      "integrity": "sha512-lg6lkOU08Az23jVcn/0Els9HP+V8PnR4Km6p0KgpTggS0n/WuhnmY64rSh83Of9iR9nD+dpWr6adlcX8KzAwjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.221.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-logs": "0.221.0",
+        "@opentelemetry/sdk-metrics": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
+      "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.221.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.221.0.tgz",
+      "integrity": "sha512-FaDcazjyMp7TZZZAsqbo4IkovP0UegoCu0EBkiNt+qCqvUf7FPAsfcrZ3+ZEkKgXZ/jHafop+JoGPDk3A0SmLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.221.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.10.0.tgz",
+      "integrity": "sha512-t6r1VSvXNtSDnPXU1FbZeetJb7yyovHmgu0wRSoftxtE0g2rSNhQZQUy69sRUCL+iioJpX8SN/S6wq6ZtvLySQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
+      "integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
+      "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-web": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-2.10.0.tgz",
+      "integrity": "sha512-6WqXdWSlBH0GNjDhv1gg6SLVtMtIBVhLaWqd1hiKSXS8meXXP13sVPQoYFHz1uVo0feUTUCdP9vMS54KflisAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/sdk-trace-base": "2.10.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.39.0.tgz",
+      "integrity": "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@redux-devtools/extension": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@redux-devtools/extension/-/extension-3.3.0.tgz",
@@ -1638,6 +2061,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT"
+    },
     "node_modules/classnames": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
@@ -1683,6 +2112,10 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "license": "MIT"
+    },
+    "node_modules/copilotstudio-webchat-react-apphost": {
+      "resolved": "apphost",
+      "link": true
     },
     "node_modules/core-js": {
       "version": "3.47.0",
@@ -1923,6 +2356,12 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
@@ -2028,6 +2467,21 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -2279,6 +2733,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.3.tgz",
+      "integrity": "sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cjs-module-lexer": "^2.2.0",
+        "es-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/inflight": {
@@ -3169,6 +3637,12 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3626,6 +4100,19 @@
       "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
       "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="
     },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
+      }
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -3928,6 +4415,509 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
+    "node_modules/tsx": {
+      "version": "4.23.5",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.5.tgz",
+      "integrity": "sha512-rw55FUaqOoI7RvlQwLbhO4nSDApnQ4/CykPuiQ/EPvtrX3WA9Ig55jIt9VvbBJbzJuj12ueRu4PMZ2SxPVbihg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/type-fest": {
       "version": "4.41.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
@@ -3938,6 +4928,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/typescript-compare": {
@@ -4160,6 +5164,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+      "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/web-speech-cognitive-services": {
       "version": "8.1.3",
       "resolved": "https://registry.npmjs.org/web-speech-cognitive-services/-/web-speech-cognitive-services-8.1.3.tgz",
@@ -4260,6 +5274,12 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/zone.js": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.16.2.tgz",
+      "integrity": "sha512-Eky7p2Z1Ig3NnbfodSPoARCjKBSTFMnE/ACsP1L/XJEfY4SdOFce19BsUCWVwL6K5ABZFy5J3bjcMWffX+YM3Q==",
+      "license": "MIT"
     },
     "node_modules/zwitch": {
       "version": "2.0.4",

--- a/samples/nodejs/copilotstudio-webchat-react/package.json
+++ b/samples/nodejs/copilotstudio-webchat-react/package.json
@@ -17,8 +17,8 @@
     "aspire": "aspire run"
   },
   "dependencies": {
-    "@azure/msal-browser": "^4.13.1",
-    "@microsoft/agents-copilotstudio-client": "^1.5.1",
+    "@azure/msal-browser": "4.13.1",
+    "@microsoft/agents-copilotstudio-client": "1.5.1",
     "@opentelemetry/api": "1.9.1",
     "@opentelemetry/context-zone": "2.10.0",
     "@opentelemetry/exporter-trace-otlp-proto": "0.221.0",
@@ -38,6 +38,6 @@
     "@microsoft/aspire-cli": "13.4.6",
     "@types/react": "16.14.65",
     "@types/react-dom": "16.9.0",
-    "esbuild": "^0.25.9"
+    "esbuild": "0.25.9"
   }
 }

--- a/samples/nodejs/copilotstudio-webchat-react/package.json
+++ b/samples/nodejs/copilotstudio-webchat-react/package.json
@@ -7,20 +7,35 @@
   "engines": {
     "node": ">=20"
   },
+  "workspaces": [
+    "apphost"
+  ],
   "scripts": {
     "prebuild": "node scripts/ensure-settings.js",
     "build": "esbuild src/index.tsx --bundle --platform=browser --target=esnext --outdir=public/dist --jsx=automatic",
-    "start": "npm run build -- --watch --serve=localhost:3000 --servedir=./public"
+    "start": "npm run build -- --watch=forever --serve=localhost:3000 --servedir=./public",
+    "aspire": "aspire run"
   },
   "dependencies": {
     "@azure/msal-browser": "^4.13.1",
     "@microsoft/agents-copilotstudio-client": "^1.5.1",
+    "@opentelemetry/api": "1.9.1",
+    "@opentelemetry/context-zone": "2.10.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "0.221.0",
+    "@opentelemetry/instrumentation": "0.221.0",
+    "@opentelemetry/instrumentation-document-load": "0.66.0",
+    "@opentelemetry/instrumentation-fetch": "0.221.0",
+    "@opentelemetry/resources": "2.10.0",
+    "@opentelemetry/sdk-trace-base": "2.10.0",
+    "@opentelemetry/sdk-trace-web": "2.10.0",
+    "@opentelemetry/semantic-conventions": "1.39.0",
     "botframework-webchat": "4.18.1-main.20251219.4ef3594",
     "botframework-webchat-fluent-theme": "4.18.1-main.20251219.4ef3594",
     "react": "16.8.6",
     "react-dom": "16.8.6"
   },
   "devDependencies": {
+    "@microsoft/aspire-cli": "13.4.6",
     "@types/react": "16.14.65",
     "@types/react-dom": "16.9.0",
     "esbuild": "^0.25.9"

--- a/samples/nodejs/copilotstudio-webchat-react/src/index.tsx
+++ b/samples/nodejs/copilotstudio-webchat-react/src/index.tsx
@@ -3,17 +3,19 @@
  * Licensed under the MIT License.
  */
 
+import './instrumentation'
 import React from 'react'
 import ReactDOM from 'react-dom'
-import Chat from './Chat'
 
-ReactDOM.render(
-  <div style={{
-    width: '100vw',
-    height: '100vh',
-    margin: 0,
-  }}
-  >
-    <Chat />
-  </div>, document.getElementById('root')
-)
+void import('./Chat').then(({ default: Chat }) => {
+  ReactDOM.render(
+    <div style={{
+      width: '100vw',
+      height: '100vh',
+      margin: 0,
+    }}
+    >
+      <Chat />
+    </div>, document.getElementById('root')
+  )
+})

--- a/samples/nodejs/copilotstudio-webchat-react/src/index.tsx
+++ b/samples/nodejs/copilotstudio-webchat-react/src/index.tsx
@@ -7,7 +7,7 @@ import './instrumentation'
 import React from 'react'
 import ReactDOM from 'react-dom'
 
-void import('./Chat').then(({ default: Chat }) => {
+import('./Chat').then(({ default: Chat }) => {
   ReactDOM.render(
     <div style={{
       width: '100vw',

--- a/samples/nodejs/copilotstudio-webchat-react/src/instrumentation.ts
+++ b/samples/nodejs/copilotstudio-webchat-react/src/instrumentation.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 import { ZoneContextManager } from '@opentelemetry/context-zone'
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto'
 import { registerInstrumentations } from '@opentelemetry/instrumentation'

--- a/samples/nodejs/copilotstudio-webchat-react/src/instrumentation.ts
+++ b/samples/nodejs/copilotstudio-webchat-react/src/instrumentation.ts
@@ -1,0 +1,22 @@
+import { ZoneContextManager } from '@opentelemetry/context-zone'
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto'
+import { registerInstrumentations } from '@opentelemetry/instrumentation'
+import { DocumentLoadInstrumentation } from '@opentelemetry/instrumentation-document-load'
+import { FetchInstrumentation } from '@opentelemetry/instrumentation-fetch'
+import { resourceFromAttributes } from '@opentelemetry/resources'
+import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base'
+import { WebTracerProvider } from '@opentelemetry/sdk-trace-web'
+import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions'
+
+const provider = new WebTracerProvider({
+  resource: resourceFromAttributes({ [ATTR_SERVICE_NAME]: 'copilotstudio-webchat-react' }),
+  spanProcessors: [new BatchSpanProcessor(new OTLPTraceExporter({ url: 'http://localhost:4318/v1/traces' }))]
+})
+
+provider.register({ contextManager: new ZoneContextManager() })
+registerInstrumentations({
+  instrumentations: [
+    new DocumentLoadInstrumentation(),
+    new FetchInstrumentation({ ignoreUrls: [/\/v1\/traces$/] })
+  ]
+})

--- a/samples/nodejs/copilotstudio-webchat-react/tsconfig.json
+++ b/samples/nodejs/copilotstudio-webchat-react/tsconfig.json
@@ -19,5 +19,6 @@
     "outDir": "public/static",
     "jsx": "react",
     "noImplicitAny": false
-  }
+  },
+  "exclude": ["apphost"]
 }

--- a/samples/nodejs/otel/.gitignore
+++ b/samples/nodejs/otel/.gitignore
@@ -1,0 +1,6 @@
+.aspire
+.env
+node_modules/
+dist/
+devTools/
+*.tsbuildinfo

--- a/samples/nodejs/otel/README.md
+++ b/samples/nodejs/otel/README.md
@@ -43,6 +43,7 @@ For local debugging, Aspire can start the agent, Agents Playground, and dashboar
 
 ```bash
 npm install
+npm run build
 npm run aspire
 ```
 

--- a/samples/nodejs/otel/README.md
+++ b/samples/nodejs/otel/README.md
@@ -37,6 +37,19 @@ If you prefer, use the included helper script, which runs the same pinned dashbo
 
 > Check the container logs (`docker logs aspire-dashboard`) for the dashboard login token.
 
+### Optional: local orchestration with Aspire
+
+For local debugging, Aspire can start the agent, Agents Playground, and dashboard together without Docker:
+
+```bash
+npm install
+npm run aspire
+```
+
+Aspire prints the dashboard URL in the terminal. Open it, then use the **URLs** column to open Playground and send the agent a message.
+
+The sample works anonymously by default. If a `.env` file contains all three Bot Service credential values, Aspire passes them only to the local Playground and labels the agent and Playground URLs **🔐 with credentials**. Otherwise it labels them **🔓 anonymous**.
+
 ### Configure Azure Bot Service
 
 1. [Create an Azure Bot](https://aka.ms/AgentsSDK-CreateBot)
@@ -110,12 +123,12 @@ If you prefer, use the included helper script, which runs the same pinned dashbo
 The `src/instrumentation.ts` file configures the OpenTelemetry Node SDK before the agent starts. It is loaded via the `--import` flag in the `start` script:
 
 ```json
-"start": "node --env-file .env --import ./dist/instrumentation.js ./dist/agent.js"
+"start": "node --env-file-if-exists=.env --import ./dist/instrumentation.js ./dist/agent.js"
 ```
 
 The `src/agentTelemetry.ts` file defines the shared telemetry helpers (tracer, counters, histograms, and structured log emitters) used by the agent handlers.
 
-By default, telemetry is exported to `http://localhost:4317` via OTLP gRPC. To change the endpoint, set the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable in your `.env` file.
+By default, telemetry is exported to `http://localhost:4317` via OTLP gRPC. To change the endpoint, set the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable in your `.env` file. The optional Aspire flow configures this endpoint automatically.
 
 ### What is instrumented
 

--- a/samples/nodejs/otel/apphost/apphost.mts
+++ b/samples/nodejs/otel/apphost/apphost.mts
@@ -1,0 +1,38 @@
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { createBuilder, OtlpProtocol } from './.aspire/modules/aspire.mjs'
+
+const envFile = join(import.meta.dirname, '../.env')
+
+if (existsSync(envFile)) {
+  process.loadEnvFile(envFile)
+}
+
+const builder = await createBuilder()
+const clientId = process.env.connections__serviceConnection__settings__clientId
+const clientSecret = process.env.connections__serviceConnection__settings__clientSecret
+const tenantId = process.env.connections__serviceConnection__settings__tenantId
+const hasCredentials = clientId && clientSecret && tenantId
+const playgroundArgs = ['run', 'agentsplayground', '--', '--port', '56150']
+const authenticationStatus = hasCredentials
+  ? { icon: '🔐', text: 'with credentials' }
+  : { icon: '🔓', text: 'anonymous' }
+
+if (hasCredentials) {
+  playgroundArgs.push('--cid', clientId, '--cs', clientSecret, '--tid', tenantId)
+}
+
+const agent = await builder
+  .addExecutable('agent', 'npm', '..', ['run', 'start'])
+  .withUrl('http://localhost:3978', { displayText: `${authenticationStatus.icon} http://localhost:3978 (${authenticationStatus.text})` })
+  .withEnvironment('PORT', '3978')
+  .withExternalHttpEndpoints()
+  .withOtlpExporter({ protocol: OtlpProtocol.Grpc })
+
+await builder
+  .addExecutable('playground', 'npm', '..', playgroundArgs)
+  .withUrl('http://localhost:56150', { displayText: `${authenticationStatus.icon} http://localhost:56150 (${authenticationStatus.text})` })
+  .withEnvironment('TEAMSAPPTESTER_BROWSER', 'none')
+  .waitFor(agent)
+
+await builder.build().run()

--- a/samples/nodejs/otel/apphost/apphost.mts
+++ b/samples/nodejs/otel/apphost/apphost.mts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { createBuilder, OtlpProtocol } from './.aspire/modules/aspire.mjs'

--- a/samples/nodejs/otel/apphost/package.json
+++ b/samples/nodejs/otel/apphost/package.json
@@ -3,11 +3,11 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "tsx": "^4.23.5",
-    "typescript": "^5.8.3",
-    "vscode-jsonrpc": "^8.2.1"
+    "tsx": "4.23.5",
+    "typescript": "5.8.3",
+    "vscode-jsonrpc": "8.2.1"
   },
   "engines": {
-    "node": "^20.19.0 || ^22.13.0 || >=24"
+    "node": ">=20"
   }
 }

--- a/samples/nodejs/otel/apphost/package.json
+++ b/samples/nodejs/otel/apphost/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "otel-apphost",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "tsx": "^4.23.5",
+    "typescript": "^5.8.3",
+    "vscode-jsonrpc": "^8.2.1"
+  },
+  "engines": {
+    "node": "^20.19.0 || ^22.13.0 || >=24"
+  }
+}

--- a/samples/nodejs/otel/apphost/tsconfig.apphost.json
+++ b/samples/nodejs/otel/apphost/tsconfig.apphost.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "./dist/apphost",
+    "rootDir": "."
+  },
+  "include": [
+    "apphost.mts",
+    ".aspire/modules/aspire.mts",
+    ".aspire/modules/base.mts",
+    ".aspire/modules/transport.mts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/samples/nodejs/otel/aspire.config.json
+++ b/samples/nodejs/otel/aspire.config.json
@@ -1,0 +1,21 @@
+{
+  "appHost": {
+    "path": "apphost/apphost.mts",
+    "language": "typescript/nodejs"
+  },
+  "packages": {
+    "Aspire.Hosting.JavaScript": "13.4.6"
+  },
+  "profiles": {
+    "http": {
+      "applicationUrl": "http://localhost:18888",
+      "environmentVariables": {
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:4317",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:18891",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true",
+        "ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS": "true",
+        "ASPIRE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/samples/nodejs/otel/package-lock.json
+++ b/samples/nodejs/otel/package-lock.json
@@ -30,19 +30,33 @@
       },
       "devDependencies": {
         "@microsoft/aspire-cli": "13.4.6",
-        "@microsoft/m365agentsplayground": "^0.2.24",
+        "@microsoft/m365agentsplayground": "0.2.24",
         "typescript": "^5.8.3"
       }
     },
     "apphost": {
       "name": "otel-apphost",
       "devDependencies": {
-        "tsx": "^4.23.5",
-        "typescript": "^5.8.3",
-        "vscode-jsonrpc": "^8.2.1"
+        "tsx": "4.23.5",
+        "typescript": "5.8.3",
+        "vscode-jsonrpc": "8.2.1"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": ">=20"
+      }
+    },
+    "apphost/node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -783,9 +797,9 @@
       ]
     },
     "node_modules/@microsoft/m365agentsplayground": {
-      "version": "0.2.28",
-      "resolved": "https://registry.npmjs.org/@microsoft/m365agentsplayground/-/m365agentsplayground-0.2.28.tgz",
-      "integrity": "sha512-EevhYW8xtEATwNg5eiFqTgZT0P5gjfCsLBwBWESSrB6+0lr9Yi9R27HJwjNGUlT3JQlxoWMgnvEQunUuyI/+2Q==",
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@microsoft/m365agentsplayground/-/m365agentsplayground-0.2.24.tgz",
+      "integrity": "sha512-Kb411Q5xSxluSJ69ViU/XeqorrjVml3tm7NHp4+7xkw0K6YWsrORun6R4GN/mUPS19zYowqlZnN+L5h5FBYM7Q==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE",
       "bin": {

--- a/samples/nodejs/otel/package-lock.json
+++ b/samples/nodejs/otel/package-lock.json
@@ -12,8 +12,8 @@
         "apphost"
       ],
       "dependencies": {
-        "@microsoft/agents-hosting": "^1.5.1",
-        "@microsoft/agents-hosting-express": "^1.5.1",
+        "@microsoft/agents-hosting": "1.5.1",
+        "@microsoft/agents-hosting-express": "1.5.1",
         "@opentelemetry/api": "1.9.1",
         "@opentelemetry/api-logs": "0.218.0",
         "@opentelemetry/exporter-logs-otlp-grpc": "0.218.0",
@@ -31,7 +31,7 @@
       "devDependencies": {
         "@microsoft/aspire-cli": "13.4.6",
         "@microsoft/m365agentsplayground": "0.2.24",
-        "typescript": "^5.8.3"
+        "typescript": "5.8.3"
       }
     },
     "apphost": {
@@ -43,20 +43,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "apphost/node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -594,9 +580,9 @@
       }
     },
     "node_modules/@microsoft/agents-activity": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/agents-activity/-/agents-activity-1.5.2.tgz",
-      "integrity": "sha512-tA+XLFQFGT76BmSq6SthDiJ7o58+aNEo+nomqC1qFHQ0ckzJbV2bOkDxrnh1RstAekAvB677PDNgVuBdPK7Izg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/agents-activity/-/agents-activity-1.5.1.tgz",
+      "integrity": "sha512-J5F7/WPvAJ5mMzwttZ5gxuJjtJ5OlCEfGdxqRTfJ/pQWwP1YA92OwfTh+6OdFga088ZWUEisQIcDWkRb5/CuGQ==",
       "license": "MIT",
       "dependencies": {
         "uuid": "11.1.0",
@@ -620,15 +606,15 @@
       }
     },
     "node_modules/@microsoft/agents-hosting": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting/-/agents-hosting-1.5.2.tgz",
-      "integrity": "sha512-aGZagBCNg7eN7yKRsk+wtewFMu/sGUgXUcvZqE5QMZhJRx3DNCRlpiki8eluuD2fjMpLBlHuJLiBJ3HyofWBUg==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting/-/agents-hosting-1.5.1.tgz",
+      "integrity": "sha512-GT3q5WhC4vkqr0dWGU4I7CshsDiQcB9Qvc8EShDGz0tkrJVK6KKyHE8DkDjhRqxrV6yMTj0zmxqa/2B1J8MjOw==",
       "license": "MIT",
       "dependencies": {
         "@azure/core-auth": "1.10.1",
         "@azure/msal-node": "5.0.6",
-        "@microsoft/agents-activity": "1.5.2",
-        "@microsoft/agents-telemetry": "1.5.2",
+        "@microsoft/agents-activity": "1.5.1",
+        "@microsoft/agents-telemetry": "1.5.1",
         "axios": "1.15.0",
         "jsonwebtoken": "9.0.3",
         "jwks-rsa": "4.0.1",
@@ -640,22 +626,22 @@
       }
     },
     "node_modules/@microsoft/agents-hosting-express": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting-express/-/agents-hosting-express-1.5.2.tgz",
-      "integrity": "sha512-IbFJwbwiqTi3i8aoSKZDh1Fh4VMvsNRBHy7xEm0HQmqjf0qxyxSn7LwwT6ai4aHPZZK8308seJDr9/WKM7URYA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/agents-hosting-express/-/agents-hosting-express-1.5.1.tgz",
+      "integrity": "sha512-tIJDxxj9m43cTQUCmahvcAau5Kxg2AA+h6py8Ef8Km6vaMKHeIj2nMeSt4ejs1BTgAWHHpGtE6bMMZR2wAHDkw==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/agents-hosting": "1.5.2",
+        "@microsoft/agents-hosting": "1.5.1",
         "express": "5.2.1"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@microsoft/agents-hosting/node_modules/@microsoft/agents-telemetry": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/agents-telemetry/-/agents-telemetry-1.5.2.tgz",
-      "integrity": "sha512-4UoWTCzz/r6kyFUvX/HSHPyMx8erD9NktIC5hQ8gxwVXlWeljry+0GI58x2Q/fcXFuAJPeJQ/+JxzyzXA9VxjA==",
+    "node_modules/@microsoft/agents-telemetry": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/agents-telemetry/-/agents-telemetry-1.5.1.tgz",
+      "integrity": "sha512-OLWDN1JgjcKb5ymGqwPuxfLgwbiYBuQ5y7dNAHQw4acplsq9299ckSaM2gev2x2rZEVEqgXa6hScSLtVXqEgww==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3"
@@ -2854,9 +2840,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/samples/nodejs/otel/package-lock.json
+++ b/samples/nodejs/otel/package-lock.json
@@ -8,6 +8,9 @@
       "name": "otel-agent",
       "version": "1.0.0",
       "license": "MIT",
+      "workspaces": [
+        "apphost"
+      ],
       "dependencies": {
         "@microsoft/agents-hosting": "^1.5.1",
         "@microsoft/agents-hosting-express": "^1.5.1",
@@ -26,7 +29,20 @@
         "@opentelemetry/semantic-conventions": "1.41.1"
       },
       "devDependencies": {
+        "@microsoft/aspire-cli": "13.4.6",
+        "@microsoft/m365agentsplayground": "^0.2.24",
         "typescript": "^5.8.3"
+      }
+    },
+    "apphost": {
+      "name": "otel-apphost",
+      "devDependencies": {
+        "tsx": "^4.23.5",
+        "typescript": "^5.8.3",
+        "vscode-jsonrpc": "^8.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -84,6 +100,448 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -202,6 +660,137 @@
         "@opentelemetry/api-logs": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@microsoft/aspire-cli": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/aspire-cli/-/aspire-cli-13.4.6.tgz",
+      "integrity": "sha512-YC1JXrFj68vQzNxqUmcAr1yN3QRPCoh/TyTWl4zs/Ow5lp1oiOIaqbhXck5DERhEWzx1Ktk2Zk3fCLYjjypCgA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "aspire": "bin/aspire.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@microsoft/aspire-cli-linux-arm64": "13.4.6",
+        "@microsoft/aspire-cli-linux-musl-x64": "13.4.6",
+        "@microsoft/aspire-cli-linux-x64": "13.4.6",
+        "@microsoft/aspire-cli-osx-arm64": "13.4.6",
+        "@microsoft/aspire-cli-osx-x64": "13.4.6",
+        "@microsoft/aspire-cli-win-arm64": "13.4.6",
+        "@microsoft/aspire-cli-win-x64": "13.4.6"
+      }
+    },
+    "node_modules/@microsoft/aspire-cli-linux-arm64": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/aspire-cli-linux-arm64/-/aspire-cli-linux-arm64-13.4.6.tgz",
+      "integrity": "sha512-utk7/R695dJvAFnJemXi2826lacMbTTq5IEsbTD6CDEr4AKEwo2P8yJ5q86/X2Tr8MtPdAgPgv5hiXNtMDXm4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@microsoft/aspire-cli-linux-musl-x64": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/aspire-cli-linux-musl-x64/-/aspire-cli-linux-musl-x64-13.4.6.tgz",
+      "integrity": "sha512-pTAOh779+E27s8iFiAIGWnmPRX8avUM620/2PNItp9PCvJ86sCLw/KPQ+NJj1G6scEMGjYNFUt/6XlS4/LqErA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@microsoft/aspire-cli-linux-x64": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/aspire-cli-linux-x64/-/aspire-cli-linux-x64-13.4.6.tgz",
+      "integrity": "sha512-Z3EIfsYU4ofSdrvbk/Ee8GoYKlFykI2Fz+gzSqn82U4o8tdYs6BMDMdmNMk9AR+H7SkhMlZhQXottc9oEJ9K2w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@microsoft/aspire-cli-osx-arm64": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/aspire-cli-osx-arm64/-/aspire-cli-osx-arm64-13.4.6.tgz",
+      "integrity": "sha512-0Dfq+9hIndbiKytAwhsNnFLgZkZ4xlMJNo80ff4tsIltd/SV9YTssxAmHXZI5v8yUH71qAZa4ttFXsH7Oc8PRA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@microsoft/aspire-cli-osx-x64": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/aspire-cli-osx-x64/-/aspire-cli-osx-x64-13.4.6.tgz",
+      "integrity": "sha512-k2WV4NSbOzNV/Kiq+4YOWZJ0yxZEgpdHzKzb7dz5rv1rMC490PzY+O5KZ9WEZd8z0XXnK/5dR62jXpkxCxjNCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@microsoft/aspire-cli-win-arm64": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/aspire-cli-win-arm64/-/aspire-cli-win-arm64-13.4.6.tgz",
+      "integrity": "sha512-UkBejnPOty6KKKG5L1jJIUYnAPoxzV1JluqJoQkOts46EBqQJbfvyzS9KTvBhNVAVj/z97T1ywwTGMm5L4sSjw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@microsoft/aspire-cli-win-x64": {
+      "version": "13.4.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/aspire-cli-win-x64/-/aspire-cli-win-x64-13.4.6.tgz",
+      "integrity": "sha512-IFNdi89nuYoWUzDRn56Lvo08C09Brm9ySGWcagxNyLbVmsngaATZSlpwhGaNz103kClEkoAa0QTc1pROULhT1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@microsoft/m365agentsplayground": {
+      "version": "0.2.28",
+      "resolved": "https://registry.npmjs.org/@microsoft/m365agentsplayground/-/m365agentsplayground-0.2.28.tgz",
+      "integrity": "sha512-EevhYW8xtEATwNg5eiFqTgZT0P5gjfCsLBwBWESSrB6+0lr9Yi9R27HJwjNGUlT3JQlxoWMgnvEQunUuyI/+2Q==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "bin": {
+        "agentsplayground": "cli.js",
+        "teamsapptester": "cli.js"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -1160,6 +1749,48 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "license": "MIT",
@@ -1325,6 +1956,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -1796,6 +2442,10 @@
         "wrappy": "1"
       }
     },
+    "node_modules/otel-apphost": {
+      "resolved": "apphost",
+      "link": true
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2139,6 +2789,25 @@
       "version": "2.8.1",
       "license": "0BSD"
     },
+    "node_modules/tsx": {
+      "version": "4.23.5",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.5.tgz",
+      "integrity": "sha512-rw55FUaqOoI7RvlQwLbhO4nSDApnQ4/CykPuiQ/EPvtrX3WA9Ig55jIt9VvbBJbzJuj12ueRu4PMZ2SxPVbihg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
     "node_modules/type-is": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
@@ -2214,6 +2883,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+      "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/wrap-ansi": {

--- a/samples/nodejs/otel/package.json
+++ b/samples/nodejs/otel/package.json
@@ -5,12 +5,19 @@
   "author": "Microsoft",
   "license": "MIT",
   "main": "./dist/agent.js",
+  "workspaces": [
+    "apphost"
+  ],
   "scripts": {
     "build": "tsc --build",
     "prestart": "npm run build",
-    "start": "node --env-file .env --import ./dist/instrumentation.js ./dist/agent.js"
+    "start": "node --env-file-if-exists=.env --import ./dist/instrumentation.js ./dist/agent.js",
+    "aspire": "aspire run",
+    "agentsplayground": "agentsplayground"
   },
   "devDependencies": {
+    "@microsoft/aspire-cli": "13.4.6",
+    "@microsoft/m365agentsplayground": "^0.2.24",
     "typescript": "^5.8.3"
   },
   "dependencies": {

--- a/samples/nodejs/otel/package.json
+++ b/samples/nodejs/otel/package.json
@@ -17,12 +17,12 @@
   },
   "devDependencies": {
     "@microsoft/aspire-cli": "13.4.6",
-    "@microsoft/m365agentsplayground": "^0.2.24",
-    "typescript": "^5.8.3"
+    "@microsoft/m365agentsplayground": "0.2.24",
+    "typescript": "5.8.3"
   },
   "dependencies": {
-    "@microsoft/agents-hosting": "^1.5.1",
-    "@microsoft/agents-hosting-express": "^1.5.1",
+    "@microsoft/agents-hosting": "1.5.1",
+    "@microsoft/agents-hosting-express": "1.5.1",
     "@opentelemetry/api": "1.9.1",
     "@opentelemetry/api-logs": "0.218.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "0.218.0",

--- a/samples/nodejs/otel/tsconfig.json
+++ b/samples/nodejs/otel/tsconfig.json
@@ -16,5 +16,6 @@
       "rootDir": "src",
       "outDir": "dist",
       "tsBuildInfoFile": "dist/.tsbuildinfo"
-  }
+  },
+  "exclude": ["apphost"]
 }


### PR DESCRIPTION
Fixes # 678

## Summary

Adds optional local Aspire orchestration for Node.js observability samples.

- Adds `npm run aspire` to the OTel agent sample.
  - Starts agent, Agents Playground, and Aspire Dashboard.
  - Supports anonymous and credentialed Playground flows.
  - Keeps Docker as the documented primary dashboard flow.

- Adds `npm run aspire` to the Copilot Studio React WebChat sample.
  - Starts WebChat through Aspire.
  - Adds browser OpenTelemetry document-load and fetch instrumentation.
  - Exports browser traces through local OTLP/HTTP.

- Adds AppHost configuration, generated-file ignores, dependencies, and TypeScript exclusions required by both samples.

## Testing
The following images show the OTel and CopilotStudio Client samples working with aspire.
<img width="1661" height="1794" alt="image" src="https://github.com/user-attachments/assets/94bd6515-bf35-4db7-b479-8d1ba3e514cf" />
<img width="1940" height="922" alt="image" src="https://github.com/user-attachments/assets/3fe1edbc-c5af-45b9-b17c-6c66ec76687c" />
